### PR TITLE
Configure debugpy python path for Windows/macOS environments

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -48,6 +48,7 @@ class DebugVSPlugin(QObject):
             import debugpy
 
             self.debugpy = debugpy
+            self.debugpy.configure(python=get_qgis_python_path())
         except:
             pass
         self.port = 5678
@@ -160,3 +161,13 @@ class DebugVSPlugin(QObject):
 
         self.debugpy.wait_for_client()
         exec(open(filename).read())
+
+def get_qgis_python_path():
+    if sys.platform.startswith("linux"):
+        return sys.executable
+    pythonExec = os.path.dirname(sys.executable)
+    if sys.platform == "win32":
+        pythonExec += "\\python3"
+    else:
+        pythonExec += "/bin/python3"
+    return pythonExec


### PR DESCRIPTION
This is similar with PR #14, but using another approach to support both Windows/macOS environments.
I get python path from the following issue/PR and I just used 2nd PR's `get_qgis_python_path` function.
1. https://github.com/qgis/QGIS/issues/45646
2. https://github.com/specklesystems/speckle-qgis/pull/126

This PR should solve all Windows/macOS related issues (#12, #13, #16, #17).

I still haven't tested this on Linux environment, but I will check it tomorrow.
=> 2024-04-29: I confirmed that Linux environment (Ubuntu 22.04 amd64, QGIS 3.34 LTS) works fine.