### PR TITLE
Update __init__.py

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -48,6 +48,7 @@ class DebugVSPlugin(QObject):
             import debugpy
 
             self.debugpy = debugpy
+            self.debugpy.configure(python="python3")
         except:
             pass
         self.port = 5678


### PR DESCRIPTION
fix to prevent QGIS implementing the plugin correctly

Edit the file init.py by adding the line `self.debugpy.configure(python="python3")` where there is the import of debugpy
```
try:
    import debugpy

    self.debugpy = debugpy
    self.debugpy.configure(python="python3")
```